### PR TITLE
RH Common provides rhevm-guest-agent-common

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,11 @@ class ovirt_guest_agent::params {
   $os = $::operatingsystem
   
   case $os {
-    'Redhat', 'CentOS', 'Scientific': {
+    'Redhat': {
+      $service_name = 'ovirt-guest-agent'
+      $package_name = 'rhevm-guest-agent-common'
+    }
+    'CentOS', 'Scientific': {
       $service_name = 'ovirt-guest-agent'
       $package_name = 'ovirt-guest-agent-common'
     }


### PR DESCRIPTION
RH Common provides rhevm-guest-agent-common which is just a rebranded version of the ovirt-guest-agent packages.

This update allow RHEL systems to stay entirely within the RH supported package set.
