### PR TITLE
Fix ovirt agent package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,11 +30,18 @@ class ovirt_guest_agent::params {
   case $os {
     'Redhat': {
       $service_name = 'ovirt-guest-agent'
-      $package_name = 'rhevm-guest-agent-common'
+      $package_name = 'ovirt-guest-agent-common'
     }
     'CentOS', 'Scientific': {
       $service_name = 'ovirt-guest-agent'
-      $package_name = 'ovirt-guest-agent-common'
+      case $::operatingsystemmajrelease {
+        '5', '6': {
+          $package_name = 'ovirt-guest-agent'
+        }
+        default: {
+          $package_name = 'ovirt-guest-agent-common'
+        }
+      }
     }
     'Debian': {
       $service_name = 'ovirt-guest-agent'


### PR DESCRIPTION
`ovirt-guest-agent-common` package install fail on CentOS 6 because in EPEL the package name for the guest agent is `ovirt-guest-agent` for EL <= 6

RHEL now provide the `ovirt-guest-common` package for RHEL6 and RHEL7